### PR TITLE
Fix!: Bump `yiisoft/yii2` constraint to `^2.0.56@dev || ^22.0@dev` to ensure `yii\web\ErrorHandler::EVENT_AFTER_RENDER` (introduced in `2.0.56`) is available at runtime.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 0.1.1 Under development
 
+- Fix!: Bump `yiisoft/yii2` constraint to `^2.0.56@dev || ^22.0@dev` to ensure `yii\web\ErrorHandler::EVENT_AFTER_RENDER` (introduced in `2.0.56`) is available at runtime.
+
 ## 0.1.0 May 17, 2026
 
 - feat: initial `yii2-extensions/debug` package structure.

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,11 @@
         "ui-awesome/html": "^0.4",
         "ui-awesome/html-helper": "^0.7",
         "ui-awesome/html-svg": "^0.4",
-        "yiisoft/yii2": "^2.0.55 || ^22.0@dev",
+        "yiisoft/yii2": "^2.0.56@dev || ^22.0@dev",
         "yiisoft/yii2-symfonymailer": "^2.0 || ^22.0@dev"
     },
     "require-dev": {
-        "infection/infection": "^0.32",
+        "infection/infection": "^0.33",
         "maglnet/composer-require-checker": "^4.1",
         "php-forge/baseline": "^0.1@dev",
         "php-forge/coding-standard": "^0.3@dev",


### PR DESCRIPTION
# Pull Request

- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
