### PR TITLE
refactor: remove redundant sidebar URL guards and eliminate 50 surviving mutants across mail search and sidebar navigation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor: remove two mutation-equivalent branches and close 34 simple mutation gaps across user switching, queues, Inertia, logs, routing, timeline rendering, and storage snapshots.
 - refactor: remove redundant filtering and tokenization branches and close 48 simple mutation gaps across configuration, dumps, searches, profiling, routing, timelines, and grid accessibility.
 - refactor: replace mutation-prone string concatenations with equivalent interpolation and formatting, removing 213 surviving mutants across debugger URLs, summaries, panels, and renderers.
+- refactor: remove redundant sidebar URL guards and eliminate 50 surviving mutants across mail search and sidebar navigation.
 
 ## 0.1.1 May 18, 2026
 

--- a/src/widgets/sidebar/SidebarDataNormalizer.php
+++ b/src/widgets/sidebar/SidebarDataNormalizer.php
@@ -12,13 +12,11 @@ use function array_key_first;
 use function array_key_last;
 use function array_keys;
 use function array_search;
-use function count;
 use function date;
 use function is_int;
 use function is_string;
 use function parse_url;
 use function reset;
-use function str_starts_with;
 
 /**
  * Builds the typed sidebar data used by history and request views.
@@ -213,7 +211,7 @@ final class SidebarDataNormalizer
         $prevTag = is_int($cursorIndex) && $cursorIndex > 0 && isset($manifestKeys[$cursorIndex - 1])
             ? $manifestKeys[$cursorIndex - 1]
             : null;
-        $nextTag = is_int($cursorIndex) && $cursorIndex < count($manifestKeys) - 1 && isset($manifestKeys[$cursorIndex + 1])
+        $nextTag = is_int($cursorIndex) && isset($manifestKeys[$cursorIndex + 1])
             ? $manifestKeys[$cursorIndex + 1]
             : null;
 
@@ -282,14 +280,10 @@ final class SidebarDataNormalizer
 
     /**
      * Strips the scheme/host/port from a captured URL so the snapshot card only shows the meaningful path + query +
-     * fragment. `php yii ...` console invocations pass through verbatim since they have no host portion.
+     * fragment. Console invocations pass through verbatim because `parse_url()` treats them as a path.
      */
     private static function urlToPath(string $url): string
     {
-        if ($url === '' || str_starts_with($url, 'php yii ')) {
-            return $url;
-        }
-
         $parsed = parse_url($url);
 
         if ($parsed === false) {

--- a/tests/mail/MailSearchTest.php
+++ b/tests/mail/MailSearchTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace yii\debug\tests\mail;
 
 use PHPUnit\Framework\Attributes\Group;
+use yii\data\{Pagination, Sort};
 use yii\debug\models\search\MailSearch;
 use yii\debug\panels\mail\MailMessage;
 use yii\debug\tests\support\TestCase;
@@ -60,16 +61,10 @@ final class MailSearchTest extends TestCase
 
     public function testRulesMarkEveryFilterAsSafe(): void
     {
-        $firstRule = (new MailSearch())->rules()[0] ?? null;
-
-        self::assertIsArray(
-            $firstRule,
-            'First rule must be a configuration tuple.',
-        );
         self::assertSame(
-            'safe',
-            $firstRule[1] ?? null,
-            "First rule must mark filter fields as 'safe'.",
+            [[['from', 'to', 'replyTo', 'cc', 'bcc', 'subject', 'body', 'charset'], 'safe']],
+            (new MailSearch())->rules(),
+            'Every searchable mail field must remain safe for mass assignment.',
         );
     }
 
@@ -91,6 +86,90 @@ final class MailSearchTest extends TestCase
             1,
             $provider->getTotalCount(),
             "Substring match on 'Order' must surface only the matching message.",
+        );
+    }
+
+    public function testSearchAppliesPartialMatchToEveryNonSubjectFilter(): void
+    {
+        $this->mockWebApplication();
+
+        $matching = MailMessage::fromCapture(
+            [
+                'from' => 'Sender Alpha <alpha@example.test>',
+                'to' => 'to-alpha@example.test',
+                'reply' => 'reply-alpha@example.test',
+                'cc' => 'cc-alpha@example.test',
+                'bcc' => 'bcc-alpha@example.test',
+                'subject' => 'Alpha subject',
+                'body' => 'Alpha message body',
+                'charset' => 'utf-8',
+            ],
+        );
+        $other = MailMessage::fromCapture(
+            [
+                'from' => 'Sender Beta <beta@example.test>',
+                'to' => 'to-beta@example.test',
+                'reply' => 'reply-beta@example.test',
+                'cc' => 'cc-beta@example.test',
+                'bcc' => 'bcc-beta@example.test',
+                'subject' => 'Beta subject',
+                'body' => 'Beta message body',
+                'charset' => 'iso-8859-1',
+            ],
+        );
+
+        $filters = [
+            'from' => 'Alpha',
+            'to' => 'to-alpha',
+            'replyTo' => 'reply-alpha',
+            'cc' => 'cc-alpha',
+            'bcc' => 'bcc-alpha',
+            'body' => 'Alpha message',
+            'charset' => 'utf',
+        ];
+
+        foreach ($filters as $attribute => $value) {
+            $provider = (new MailSearch())->search(
+                ['MailSearch' => [$attribute => $value]],
+                [$matching, $other],
+            );
+
+            self::assertSame(
+                [$matching],
+                $provider->allModels,
+                "The '{$attribute}' filter must apply a partial match.",
+            );
+        }
+    }
+
+    public function testSearchConfiguresPaginationAndSorting(): void
+    {
+        $this->mockWebApplication();
+
+        $provider = (new MailSearch())->search([], []);
+
+        $pagination = $provider->getPagination();
+        $sort = $provider->getSort();
+
+        self::assertInstanceOf(
+            Pagination::class,
+            $pagination,
+            'Mail results must remain paginated.',
+        );
+        self::assertSame(
+            20,
+            $pagination->getPageSize(),
+            'Mail results must preserve the configured default page size.',
+        );
+        self::assertInstanceOf(
+            Sort::class,
+            $sort,
+            'Mail results must remain sortable.',
+        );
+        self::assertSame(
+            ['from', 'to', 'replyTo', 'cc', 'bcc', 'subject', 'body', 'charset'],
+            array_keys($sort->attributes),
+            'Every displayed mail field must remain sortable.',
         );
     }
 

--- a/tests/widgets/sidebar/SidebarDataNormalizerTest.php
+++ b/tests/widgets/sidebar/SidebarDataNormalizerTest.php
@@ -64,10 +64,15 @@ final class SidebarDataNormalizerTest extends TestCase
 
         $panelItem = $view->navItems[1];
 
-        self::assertContains(
-            'tag-newest',
+        self::assertSame(
+            ['view', 'tag' => 'tag-newest', 'panel' => 'request'],
             $panelItem->url,
-            'Index-mode panel link must carry the newest tag.',
+            'Index-mode panel link must carry its route, newest tag, and panel ID.',
+        );
+        self::assertStringContainsString(
+            '<svg',
+            $panelItem->iconSvg,
+            'A panel toolbar icon must be rendered into the navigation item.',
         );
         self::assertSame(
             'Open this panel on the newest request',
@@ -173,6 +178,39 @@ final class SidebarDataNormalizerTest extends TestCase
             $view->snapshot->title,
             "Index mode must use the 'Newest request' heading.",
         );
+        self::assertSame(
+            'Newest captured request',
+            $view->snapshot->ariaLabel,
+            'Index mode must expose the expanded snapshot aria-label.',
+        );
+        self::assertSame(
+            ['view', 'tag' => 'tag-1'],
+            $view->snapshot->newestUrl,
+            'A navigator without panels must omit the panel parameter.',
+        );
+        self::assertSame(
+            ['view', 'tag' => 'tag-1'],
+            $view->snapshot->oldestUrl,
+            'The single snapshot must be both the newest and oldest destination.',
+        );
+        self::assertSame(
+            [],
+            $view->snapshot->newerUrl,
+            'The newest snapshot must not expose a newer destination.',
+        );
+        self::assertSame(
+            [],
+            $view->snapshot->olderUrl,
+            'The oldest snapshot must not expose an older destination.',
+        );
+        self::assertTrue(
+            $view->snapshot->isNewest,
+            'A single snapshot must be marked as newest.',
+        );
+        self::assertTrue(
+            $view->snapshot->isOldest,
+            'A single snapshot must be marked as oldest.',
+        );
     }
 
     public function testFromIndexSurfacesNewestTagAsSnapshot(): void
@@ -212,10 +250,15 @@ final class SidebarDataNormalizerTest extends TestCase
         $this->mockWebApplication();
 
         $panel = new RequestPanel();
+
         $panel->id = 'request';
 
+        $inactivePanel = new RequestPanel();
+
+        $inactivePanel->id = 'other';
+
         $view = SidebarDataNormalizer::fromView(
-            ['request' => $panel],
+            ['request' => $panel, 'other' => $inactivePanel],
             ['tag-1' => $this->requestSummary()],
             $panel,
             'tag-1',
@@ -227,10 +270,34 @@ final class SidebarDataNormalizerTest extends TestCase
             $view->navItems,
             'History must include at least one navigation item.',
         );
-        self::assertContains(
-            'tag-1',
+        self::assertSame(
+            ['index', 'cursor' => 'tag-1'],
             $view->navItems[0]->url,
-            "History entry must carry the active tag as 'cursor'.",
+            "History entry must carry the active tag as the exact 'cursor' route.",
+        );
+
+        $panelItem = $view->navItems[1] ?? self::fail('Request panel navigation item must surface.');
+
+        self::assertSame(
+            ['view', 'tag' => 'tag-1', 'panel' => 'request'],
+            $panelItem->url,
+            'View-mode panel link must preserve the active capture and panel.',
+        );
+        self::assertSame(
+            'Request',
+            $panelItem->tooltip,
+            'View-mode panel tooltip must use the panel name.',
+        );
+        self::assertTrue(
+            $panelItem->isActive,
+            'View mode must mark the selected panel as active.',
+        );
+
+        $inactiveItem = $view->navItems[2] ?? self::fail('Inactive panel navigation item must surface.');
+
+        self::assertFalse(
+            $inactiveItem->isActive,
+            'View mode must not mark other panels as active.',
         );
     }
 
@@ -317,6 +384,41 @@ final class SidebarDataNormalizerTest extends TestCase
             $view->snapshot->title,
             "View mode must use the 'Current request' heading.",
         );
+        self::assertSame(
+            'Current request',
+            $view->snapshot->ariaLabel,
+            "View mode must use the 'Current request' aria-label.",
+        );
+    }
+
+    public function testFromViewOmitsTagFromBoundaryUrlsWhenManifestIsEmpty(): void
+    {
+        $this->mockWebApplication();
+
+        $panel = new RequestPanel();
+
+        $panel->id = 'request';
+
+        $view = SidebarDataNormalizer::fromView(
+            ['request' => $panel],
+            [],
+            $panel,
+            'tag-1',
+            $this->requestSummary(),
+        );
+
+        $snapshot = $view->snapshot ?? self::fail('View mode must carry the supplied snapshot.');
+
+        self::assertSame(
+            ['view', 'panel' => 'request'],
+            $snapshot->newestUrl,
+            'An empty manifest must omit the missing newest tag.',
+        );
+        self::assertSame(
+            ['view', 'panel' => 'request'],
+            $snapshot->oldestUrl,
+            'An empty manifest must omit the missing oldest tag.',
+        );
     }
 
     public function testFromViewPopulatesPrevAndNextNavigatorsWhenSnapshotIsMiddleOfManifest(): void
@@ -352,6 +454,24 @@ final class SidebarDataNormalizerTest extends TestCase
         self::assertTrue(
             $view->snapshot->hasOlder,
             'Middle-tag snapshot must expose a older navigator.',
+        );
+        self::assertSame(
+            ['view', 'tag' => 'tag-newest', 'panel' => 'request'],
+            $view->snapshot->newerUrl,
+            'Middle-tag snapshot must link to the immediately newer capture.',
+        );
+        self::assertSame(
+            ['view', 'tag' => 'tag-oldest', 'panel' => 'request'],
+            $view->snapshot->olderUrl,
+            'Middle-tag snapshot must link to the immediately older capture.',
+        );
+        self::assertFalse(
+            $view->snapshot->isNewest,
+            'Middle-tag snapshot must not be marked as newest.',
+        );
+        self::assertFalse(
+            $view->snapshot->isOldest,
+            'Middle-tag snapshot must not be marked as oldest.',
         );
     }
 
@@ -440,6 +560,11 @@ final class SidebarDataNormalizerTest extends TestCase
             $ids,
             'Config panel must be skipped in the sidebar nav.',
         );
+        self::assertContains(
+            'Request',
+            $ids,
+            'Panels after Configuration must remain available.',
+        );
     }
 
     public function testFromViewSkipsPanelsWithoutContentForTheCapture(): void
@@ -454,7 +579,7 @@ final class SidebarDataNormalizerTest extends TestCase
         $this->hydratePanel($inertia, InertiaSnapshot::capture(null, null, [], [], 200));
 
         $view = SidebarDataNormalizer::fromView(
-            ['request' => $active, 'inertia' => $inertia],
+            ['inertia' => $inertia, 'request' => $active],
             ['tag-1' => $this->requestSummary()],
             $active,
             'tag-1',

--- a/tests/widgets/sidebar/SidebarRendererTest.php
+++ b/tests/widgets/sidebar/SidebarRendererTest.php
@@ -55,6 +55,11 @@ final class SidebarRendererTest extends TestCase
             substr_count($html, 'is-active'),
             'Only the active entry carries the modifier.',
         );
+        self::assertMatchesRegularExpression(
+            '/<a class="yii-debug-nav-link is-active"[^>]*title="History"[^>]*aria-current="page">/',
+            $html,
+            'The active link must preserve its base class, tooltip, and current-page marker.',
+        );
     }
 
     public function testRenderEmitsCursorButtonsWhenSnapshotIsCursor(): void
@@ -93,9 +98,9 @@ final class SidebarRendererTest extends TestCase
         $html = SidebarRenderer::render($view);
 
         self::assertStringContainsString(
-            'data-yii-debug-history-cursor',
+            'data-yii-debug-history-cursor="true"',
             $html,
-            'Cursor mode must emit the history-cursor marker.',
+            'Cursor mode must emit a true history-cursor marker.',
         );
         self::assertStringContainsString(
             'data-yii-debug-cursor-init="init-tag"',
@@ -130,6 +135,11 @@ final class SidebarRendererTest extends TestCase
             'data-test="request-icon"',
             $html,
             'Icon SVG payload must surface inside the nav link.',
+        );
+        self::assertStringContainsString(
+            'aria-hidden="true"',
+            $html,
+            'Decorative panel icons must remain hidden from assistive technology.',
         );
     }
 
@@ -241,6 +251,21 @@ final class SidebarRendererTest extends TestCase
             'aria-label="Newest captured request"',
             $html,
             "Navigation mode must use the long 'aria-label' for Newest.",
+        );
+        self::assertStringContainsString(
+            'title="GET http://example.test/index.php"',
+            $html,
+            'Snapshot tooltip must prefix the URL with the request method.',
+        );
+        self::assertMatchesRegularExpression(
+            '/<button class="[^"]*is-disabled"[^>]*aria-label="Newer captured request">/',
+            $html,
+            'A missing newer capture must render a disabled button.',
+        );
+        self::assertMatchesRegularExpression(
+            '/<a[^>]*href="[^"]*tag=older"[^>]*aria-label="Older captured request">/',
+            $html,
+            'An available older capture must render an anchor to its tag.',
         );
         self::assertStringNotContainsString(
             'data-yii-debug-cursor=',


### PR DESCRIPTION
# Pull Request

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bugfix (non-breaking change that fixes an issue)
- [ ] CI/build configuration
- [ ] Documentation update
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Refactoring (no functional changes)
